### PR TITLE
Fix right-click disconnect list showing wrong port names

### DIFF
--- a/graph/port_item.py
+++ b/graph/port_item.py
@@ -345,7 +345,7 @@ class PortItem(QGraphicsItem):
             action.setEnabled(False)
         else:
             for out_port_name, in_port_name in connections:
-                other_port_name = in_port_name if self.is_input else out_port_name
+                other_port_name = out_port_name if self.is_input else in_port_name
                 other_short_name = other_port_name.split(':')[-1]
                 client_name = other_port_name.split(':')[0]
 


### PR DESCRIPTION
Fixed the logic in port_item.py contextMenuEvent where the disconnect menu was showing the current port name instead of the connected port name. For input ports, we now correctly show the output port we're connected to, and for output ports, we show the input port we're connected to.

Fixes #19 
